### PR TITLE
Fix pre-SQL Server 2016 compatibility of "drop table if exists" when disposing temp tables.

### DIFF
--- a/samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples.csproj
+++ b/samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     </ItemGroup>

--- a/samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples.csproj
+++ b/samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples/Thinktecture.EntityFrameworkCore.SqlServer.Samples.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.4" PrivateAssets="all" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     </ItemGroup>

--- a/samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples.csproj
+++ b/samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     </ItemGroup>

--- a/samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples.csproj
+++ b/samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples/Thinktecture.EntityFrameworkCore.Sqlite.Samples.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     </ItemGroup>

--- a/src/Thinktecture.EntityFrameworkCore.Relational/Thinktecture.EntityFrameworkCore.Relational.csproj
+++ b/src/Thinktecture.EntityFrameworkCore.Relational/Thinktecture.EntityFrameworkCore.Relational.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.2" />
-      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
+      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/Thinktecture.EntityFrameworkCore.Relational/Thinktecture.EntityFrameworkCore.Relational.csproj
+++ b/src/Thinktecture.EntityFrameworkCore.Relational/Thinktecture.EntityFrameworkCore.Relational.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
-      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.4" />
+      <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/Thinktecture.EntityFrameworkCore.SqlServer/EntityFrameworkCore/TempTables/SqlServerTempTableReference.cs
+++ b/src/Thinktecture.EntityFrameworkCore.SqlServer/EntityFrameworkCore/TempTables/SqlServerTempTableReference.cs
@@ -59,7 +59,10 @@ public sealed class SqlServerTempTableReference : ITempTableReference
          if (!_dropTableOnDispose || _database.GetDbConnection().State != ConnectionState.Open)
             return;
 
-         _database.ExecuteSqlRaw($"DROP TABLE IF EXISTS {_sqlGenerationHelper.DelimitIdentifier(Name)}");
+         _database.ExecuteSqlRaw($@"
+IF(OBJECT_ID('tempdb..{Name}') IS NOT NULL)
+   DROP TABLE {_sqlGenerationHelper.DelimitIdentifier(Name)};
+");
          _database.CloseConnection();
       }
       catch (ObjectDisposedException ex)

--- a/src/Thinktecture.EntityFrameworkCore.SqlServer/Thinktecture.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Thinktecture.EntityFrameworkCore.SqlServer/Thinktecture.EntityFrameworkCore.SqlServer.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/Thinktecture.EntityFrameworkCore.SqlServer/Thinktecture.EntityFrameworkCore.SqlServer.csproj
+++ b/src/Thinktecture.EntityFrameworkCore.SqlServer/Thinktecture.EntityFrameworkCore.SqlServer.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/Thinktecture.EntityFrameworkCore.Sqlite/Thinktecture.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Thinktecture.EntityFrameworkCore.Sqlite/Thinktecture.EntityFrameworkCore.Sqlite.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.4" />
     </ItemGroup>
 
 </Project>

--- a/src/Thinktecture.EntityFrameworkCore.Sqlite/Thinktecture.EntityFrameworkCore.Sqlite.csproj
+++ b/src/Thinktecture.EntityFrameworkCore.Sqlite/Thinktecture.EntityFrameworkCore.Sqlite.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
     </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -9,7 +9,7 @@
     <Import Condition="exists('$(ParentPropsFile)') " Project="$(ParentPropsFile)"/>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.5.1"/>
+        <PackageReference Include="FluentAssertions" Version="6.6.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
         <PackageReference Include="Moq" Version="4.17.2"/>
         <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -9,9 +9,9 @@
     <Import Condition="exists('$(ParentPropsFile)') " Project="$(ParentPropsFile)"/>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.4.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
-        <PackageReference Include="Moq" Version="4.16.1"/>
+        <PackageReference Include="FluentAssertions" Version="6.5.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageReference Include="Moq" Version="4.17.2"/>
         <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>
         <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.3"/>
         <PackageReference Include="xunit" Version="2.4.1"/>

--- a/tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.4" />
     </ItemGroup>
 
 </Project>

--- a/tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests/Thinktecture.EntityFrameworkCore.BulkOperations.Tests.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
     </ItemGroup>
 
 </Project>

--- a/tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     </ItemGroup>

--- a/tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests/Thinktecture.EntityFrameworkCore.SqlServer.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     </ItemGroup>

--- a/tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.4" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     </ItemGroup>

--- a/tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests/Thinktecture.EntityFrameworkCore.Sqlite.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.2" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     </ItemGroup>

--- a/tests/Thinktecture.EntityFrameworkCore.TestHelpers/Thinktecture.EntityFrameworkCore.TestHelpers.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.TestHelpers/Thinktecture.EntityFrameworkCore.TestHelpers.csproj
@@ -5,7 +5,7 @@
    </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.2" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
    </ItemGroup>
    
 </Project>

--- a/tests/Thinktecture.EntityFrameworkCore.TestHelpers/Thinktecture.EntityFrameworkCore.TestHelpers.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.TestHelpers/Thinktecture.EntityFrameworkCore.TestHelpers.csproj
@@ -5,7 +5,7 @@
    </PropertyGroup>
 
    <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.4" />
    </ItemGroup>
    
 </Project>

--- a/tests/Thinktecture.EntityFrameworkCore.Testing.Tests/Thinktecture.EntityFrameworkCore.Testing.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.Testing.Tests/Thinktecture.EntityFrameworkCore.Testing.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/Thinktecture.EntityFrameworkCore.Testing.Tests/Thinktecture.EntityFrameworkCore.Testing.Tests.csproj
+++ b/tests/Thinktecture.EntityFrameworkCore.Testing.Tests/Thinktecture.EntityFrameworkCore.Testing.Tests.csproj
@@ -5,7 +5,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This is the only thing preventing the temp table support of the library from working with SQL Server 2014 and as far as I'm aware there is no advantages to using `DROP TABLE IF EXISTS #tbl` over `IF(OBJECT_ID('tempdb..#tbl') IS NOT NULL)  DROP TABLE [#tbl];`.

Fixes #19, fixes #6