### PR TITLE
Previous attempt to fix pre-sql server 2016 support for temp tables missed the DisposeAsync implementation.

### DIFF
--- a/src/Thinktecture.EntityFrameworkCore.SqlServer/EntityFrameworkCore/TempTables/SqlServerTempTableReference.cs
+++ b/src/Thinktecture.EntityFrameworkCore.SqlServer/EntityFrameworkCore/TempTables/SqlServerTempTableReference.cs
@@ -88,7 +88,10 @@ IF(OBJECT_ID('tempdb..{Name}') IS NOT NULL)
          if (!_dropTableOnDispose || _database.GetDbConnection().State != ConnectionState.Open)
             return;
 
-         await _database.ExecuteSqlRawAsync($"DROP TABLE IF EXISTS {_sqlGenerationHelper.DelimitIdentifier(Name)}").ConfigureAwait(false);
+         await _database.ExecuteSqlRawAsync($@"
+IF(OBJECT_ID('tempdb..{Name}') IS NOT NULL)
+   DROP TABLE {_sqlGenerationHelper.DelimitIdentifier(Name)};
+").ConfigureAwait(false);
          await _database.CloseConnectionAsync().ConfigureAwait(false);
       }
       catch (ObjectDisposedException ex)


### PR DESCRIPTION
My fix in #21 went a bit too fast because I missed that SqlServerTempTableReference.DisposeAsync() had the same sql.