### PR TITLE
Temp tables: Delimit identifier for primary key columns

### DIFF
--- a/src/Thinktecture.EntityFrameworkCore.SqlServer/EntityFrameworkCore/TempTables/SqlServerTempTableCreator.cs
+++ b/src/Thinktecture.EntityFrameworkCore.SqlServer/EntityFrameworkCore/TempTables/SqlServerTempTableCreator.cs
@@ -143,7 +143,7 @@ public sealed class SqlServerTempTableCreator : ISqlServerTempTableCreator
       var columnNames = cacheKey.KeyProperties.Select(p =>
                                                       {
                                                          var storeObject = p.GetStoreObject();
-                                                         return p.GetColumnName(storeObject);
+                                                         return sqlGenerationHelper.DelimitIdentifier(p.GetColumnName(storeObject));
                                                       });
 
       var commaSeparatedColumns = String.Join(", ", columnNames);


### PR DESCRIPTION
This PR fixes an edge case: For SQL Server, when inserting into a temp table with a defined primary key, and the key is created after insertion, the column names were not escaped. This caused an error when a column name is the same as an SQL keyword (such as `Key`).

The fix: `DelimitIdentifier` for each column name, similarly to the other methods.